### PR TITLE
Add consent step to onboarding

### DIFF
--- a/src/app/api/user/consent/route.ts
+++ b/src/app/api/user/consent/route.ts
@@ -1,0 +1,1 @@
+export * from '@/features/user/api/consent/route'

--- a/src/app/api/user/onboarding-status/route.ts
+++ b/src/app/api/user/onboarding-status/route.ts
@@ -22,6 +22,8 @@ export async function GET() {
         assistantTone: true,
         currentInstitution: true,
         currentDepartment: true,
+        agreedToPrivacyPolicy: true,
+        agreedToTermsOfService: true,
       }
     })
 
@@ -39,17 +41,22 @@ export async function GET() {
           assistantTone: true,
           currentInstitution: true,
           currentDepartment: true,
+          agreedToPrivacyPolicy: true,
+          agreedToTermsOfService: true,
         }
       })
     }
 
     // Determine onboarding status
+    const hasConsent = !!(user.agreedToPrivacyPolicy && user.agreedToTermsOfService)
     const hasE2EE = !!user.encryptedDEK_password
     const hasPreferences = !!(user.assistantName && user.assistantTone)
 
     // Determine next step
     let nextStep = null
-    if (!hasE2EE) {
+    if (!hasConsent) {
+      nextStep = 'consent'
+    } else if (!hasE2EE) {
       nextStep = 'e2ee'
     } else if (!hasPreferences) {
       nextStep = 'preferences'
@@ -58,6 +65,7 @@ export async function GET() {
     }
 
     return NextResponse.json({
+      hasConsent,
       hasE2EE,
       hasPreferences,
       nextStep,

--- a/src/app/onboarding/consent/page.tsx
+++ b/src/app/onboarding/consent/page.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+
+export default function ConsentOnboardingPage() {
+  const { status } = useSession()
+  const router = useRouter()
+  const [privacy, setPrivacy] = useState(false)
+  const [terms, setTerms] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen bg-white flex items-center justify-center">
+        <div className="text-xl">Loading...</div>
+      </div>
+    )
+  }
+
+  if (status === 'unauthenticated') {
+    return null
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!privacy || !terms) {
+      setError('You must agree to the privacy policy and terms of service.')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/user/consent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({})
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error || 'Failed to save consent')
+      }
+      router.push('/onboarding/e2ee')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save consent')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-white">
+      <header className="bg-white">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-16 flex items-center">
+          <div className="text-2xl font-extrabold tracking-tight text-gray-900 font-['Nanum_Myeongjo']">
+            ToPhD
+          </div>
+        </div>
+      </header>
+      <main className="flex-1 flex items-center justify-center px-6 lg:px-8 py-20">
+        <div className="max-w-xl mx-auto w-full">
+          <h1 className="text-4xl sm:text-5xl font-black mb-8 text-center font-['Nanum_Myeongjo']">
+            One more step
+          </h1>
+          <p className="text-lg text-gray-700 mb-8 text-center font-['Nanum_Myeongjo']">
+            Please review and agree to the privacy policy and terms of service.
+          </p>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="flex items-start">
+              <input
+                id="privacy"
+                type="checkbox"
+                checked={privacy}
+                onChange={e => setPrivacy(e.target.checked)}
+                className="mt-1 mr-3"
+              />
+              <label htmlFor="privacy" className="font-['Nanum_Myeongjo'] text-gray-900">
+                I agree to the{' '}
+                <a href="/privacy.html" target="_blank" className="underline">Privacy Policy</a>
+              </label>
+            </div>
+            <div className="flex items-start">
+              <input
+                id="terms"
+                type="checkbox"
+                checked={terms}
+                onChange={e => setTerms(e.target.checked)}
+                className="mt-1 mr-3"
+              />
+              <label htmlFor="terms" className="font-['Nanum_Myeongjo'] text-gray-900">
+                I agree to the{' '}
+                <a href="/terms.html" target="_blank" className="underline">Terms of Service</a>
+              </label>
+            </div>
+            {error && (
+              <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
+                <p className="text-gray-700 font-['Nanum_Myeongjo']">{error}</p>
+              </div>
+            )}
+            <div className="pt-4">
+              <button
+                type="submit"
+                disabled={submitting}
+                className="w-full inline-flex items-center justify-center rounded-lg px-8 h-14 text-lg font-semibold text-white bg-gray-900 hover:bg-gray-800 active:bg-black transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 shadow-lg hover:shadow-xl disabled:opacity-50 disabled:cursor-not-allowed font-['Nanum_Myeongjo']"
+              >
+                {submitting ? 'Submitting...' : 'Continue'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,10 +26,11 @@ export default function HomePage() {
           }
           
           const onboardingData = await onboardingResponse.json()
-          
-          // If onboarding is not complete, let middleware handle the redirect
+
+          // If onboarding is not complete, redirect to the next step
           if (!onboardingData.isComplete) {
             setIsChecking(false)
+            router.push(`/onboarding/${onboardingData.nextStep}`)
             return
           }
 
@@ -51,7 +52,7 @@ export default function HomePage() {
     }
 
     checkUserStatus()
-  }, [session, isRedirecting])
+  }, [session, isRedirecting, router])
 
   // Handle redirects after status is determined
   useEffect(() => {

--- a/src/features/user/api/consent/route.ts
+++ b/src/features/user/api/consent/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/lib/authOptions'
+import { prisma } from '../../../../lib/prisma'
+
+export async function POST(_req: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions)
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Ensure user exists
+    const email = session.user.email
+    await prisma.user.upsert({
+      where: { email },
+      update: {
+        agreedToPrivacyPolicy: new Date(),
+        agreedToTermsOfService: new Date()
+      },
+      create: {
+        email,
+        name: session.user.name,
+        image: session.user.image,
+        agreedToPrivacyPolicy: new Date(),
+        agreedToTermsOfService: new Date()
+      }
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error saving consent:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -50,12 +50,14 @@ export async function middleware(request: NextRequest) {
         
         // If onboarding is not complete, redirect to appropriate step
         if (!isComplete) {
-          let redirectUrl = '/onboarding/e2ee'
-          
-          if (nextStep === 'preferences') {
+          let redirectUrl = '/onboarding/consent'
+
+          if (nextStep === 'e2ee') {
+            redirectUrl = '/onboarding/e2ee'
+          } else if (nextStep === 'preferences') {
             redirectUrl = '/onboarding/preferences'
           }
-          
+
           return NextResponse.redirect(new URL(redirectUrl, request.url))
         }
       }


### PR DESCRIPTION
## Summary
- add a consent page to agree to privacy policy and terms
- store consent with new `/api/user/consent` endpoint
- track consent in onboarding status
- redirect based on new step in middleware and home page

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6886c1b6785c8332a7be30f20ff79fb4